### PR TITLE
Feature/db command prepare

### DIFF
--- a/Kros.KORM/src/Kros.KORM/CommandGenerator/CommandGenerator.cs
+++ b/Kros.KORM/src/Kros.KORM/CommandGenerator/CommandGenerator.cs
@@ -203,7 +203,6 @@ namespace Kros.KORM.CommandGenerator
                     DbParameter parameter = command.Parameters[paramName];
                     var val = GetColumnValue(colInfo, item);
                     parameter.Value = val ?? System.DBNull.Value;
-                    _provider.SetParameterDbType(parameter, _tableInfo.Name, colInfo.Name);
                 }
             }
         }
@@ -267,6 +266,7 @@ namespace Kros.KORM.CommandGenerator
             {
                 var par = cmd.CreateParameter();
                 par.ParameterName = $"@{colInfo.Name}";
+                _provider.SetParameterDbType(par, _tableInfo.Name, colInfo.Name);
                 cmd.Parameters.Add(par);
             }
         }

--- a/Kros.KORM/src/Kros.KORM/Query/DbSet.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/DbSet.cs
@@ -278,6 +278,8 @@ namespace Kros.KORM.Query
             GeneratePrimaryKeys(items);
             using (DbCommand command = _commandGenerator.GetInsertCommand())
             {
+                command.Prepare();
+
                 foreach (T item in items)
                 {
                     _commandGenerator.FillCommand(command, item);
@@ -312,6 +314,8 @@ namespace Kros.KORM.Query
         {
             using (DbCommand command = _commandGenerator.GetUpdateCommand())
             {
+                command.Prepare();
+
                 foreach (T item in items)
                 {
                     _commandGenerator.FillCommand(command, item);

--- a/Kros.KORM/src/Kros.KORM/Query/DbSet.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/DbSet.cs
@@ -278,8 +278,6 @@ namespace Kros.KORM.Query
             GeneratePrimaryKeys(items);
             using (DbCommand command = _commandGenerator.GetInsertCommand())
             {
-                command.Prepare();
-
                 foreach (T item in items)
                 {
                     _commandGenerator.FillCommand(command, item);
@@ -314,8 +312,6 @@ namespace Kros.KORM.Query
         {
             using (DbCommand command = _commandGenerator.GetUpdateCommand())
             {
-                command.Prepare();
-
                 foreach (T item in items)
                 {
                     _commandGenerator.FillCommand(command, item);

--- a/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
@@ -170,6 +170,7 @@ namespace Kros.KORM.Query
                     tableName, columnName));
             }
             table.Columns[columnName].SetParameterDbType(parameter);
+            parameter.Size = table.Columns[columnName].Size;
         }
 
         private TableSchema LoadTableSchema(string tableName)

--- a/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
@@ -170,7 +170,6 @@ namespace Kros.KORM.Query
                     tableName, columnName));
             }
             table.Columns[columnName].SetParameterDbType(parameter);
-            parameter.Size = table.Columns[columnName].Size;
         }
 
         private TableSchema LoadTableSchema(string tableName)

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -29,6 +29,11 @@ namespace Kros.KORM.UnitTests.Integration
 ) ON[PRIMARY];
 ";
 
+        private static string InsertDataScript =
+            $@"INSERT INTO {Table_TestTable} VALUES (1, 18, 'John', 'Smith', 'London');
+INSERT INTO {Table_TestTable} VALUES (1, 22, 'Kilie', 'Bistrol', 'London');
+";
+
         #endregion
 
         [Fact]
@@ -48,6 +53,43 @@ namespace Kros.KORM.UnitTests.Integration
                 });
 
                 dbSet.Add(new Person()
+                {
+                    Id = 2,
+                    FirstName = "Peter",
+                    LastName = "Juráček",
+                    Age = 14,
+                    Address = new List<string>() { "Novozámocká" }
+                });
+
+                dbSet.CommitChanges();
+
+                var person = korm.Query<Person>().FirstOrDefault(p => p.Id == 1);
+
+                person.Id.Should().Be(1);
+                person.Age.Should().Be(32);
+                person.FirstName.Should().Be("Milan");
+                person.LastName.Should().Be("Martiniak");
+                person.Address.ShouldBeEquivalentTo(new List<string>() { "Petzvalova", "Pekna", "Zelena" });
+            }
+        }
+
+        [Fact]
+        public void UpdateData()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+
+                dbSet.Edit(new Person()
+                {
+                    Id = 1,
+                    FirstName = "Milan",
+                    LastName = "Martiniak",
+                    Age = 32,
+                    Address = new List<string>() { "Petzvalova", "Pekna", "Zelena" }
+                });
+
+                dbSet.Edit(new Person()
                 {
                     Id = 2,
                     FirstName = "Peter",


### PR DESCRIPTION
Implement issue #59 .

- I moved the call of ```SetParameterDbType``` from ```FillCommand``` method to ```AddParametersToCommand```.
- Call ```DbCommand.Prepare()``` to increase performance for CommitChanges commands on MsSQL server.