### PR TITLE
Support for .NET Core 2.1

### DIFF
--- a/Kros.KORM/src/Kros.KORM.MsAccess/Properties/AssemblyInfo.cs
+++ b/Kros.KORM/src/Kros.KORM.MsAccess/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.2.0")]
-[assembly: AssemblyFileVersion("1.6.2.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]

--- a/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
+++ b/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
     <Company>KROS a.s.</Company>
-    <Version>3.6.3</Version>
+    <Version>3.7.0</Version>
     <Authors>KROS a.s.</Authors>
     <Title>Kros.KORM</Title>
     <Description>KORM is fast, easy to use, micro .NET Standard ORM tool. (Kros Object Relation Mapper)</Description>

--- a/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
+++ b/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
     <Company>KROS a.s.</Company>
     <Version>3.6.3</Version>
     <Authors>KROS a.s.</Authors>
@@ -32,11 +32,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <Version>4.4.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Configuration.ConfigurationManager">
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Kros.KORM/tests/Kros.KORM.MsAccess.UnitTests/Kros.KORM.MsAccess.UnitTests.csproj
+++ b/Kros.KORM/tests/Kros.KORM.MsAccess.UnitTests/Kros.KORM.MsAccess.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -47,10 +47,10 @@
       <HintPath>..\..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -102,7 +102,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+    <Analyzer Include="..\..\..\packages\xunit.analyzers.0.9.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -110,12 +110,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
+  <Import Project="..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Kros.KORM/tests/Kros.KORM.MsAccess.UnitTests/packages.config
+++ b/Kros.KORM/tests/Kros.KORM.MsAccess.UnitTests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
-  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net462" />
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net462" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net462" />
   <package id="xunit" version="2.3.1" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net462" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.9.0" targetFramework="net462" />
   <package id="xunit.assert" version="2.3.1" targetFramework="net462" />
   <package id="xunit.core" version="2.3.1" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net462" />

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Company>Kros a.s.</Company>
   </PropertyGroup>

--- a/Kros.KORM/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
+++ b/Kros.KORM/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>Kros a.s.</Authors>
     <Company>Kros a.s.</Company>

--- a/Kros.Utils/src/Kros.Utils.MsAccess/Properties/AssemblyInfo.cs
+++ b/Kros.Utils/src/Kros.Utils.MsAccess/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]

--- a/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
+++ b/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
     <Company>KROS a.s.</Company>
     <Title>Kros.Utils</Title>
     <Version>1.6.0</Version>
@@ -33,6 +33,7 @@
     <EmbeddedResource Include="Resources\SqlIdGeneratorTableScript.sql" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
+++ b/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
     <Company>KROS a.s.</Company>
     <Title>Kros.Utils</Title>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <Authors>KROS a.s.</Authors>
     <Description>General utilities and helpers.</Description>
     <Copyright>Copyright © KROS a.s.</Copyright>

--- a/Kros.Utils/tests/Kros.Utils.MsAccess.UnitTests/Kros.Utils.MsAccess.UnitTests.csproj
+++ b/Kros.Utils/tests/Kros.Utils.MsAccess.UnitTests/Kros.Utils.MsAccess.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.props" Condition="Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.props')" />
   <Import Project="..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.props" Condition="Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -57,15 +57,18 @@
     <Reference Include="Nito.AsyncEx.Tasks, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Nito.AsyncEx.Tasks.5.0.0-pre-05\lib\netstandard2.0\Nito.AsyncEx.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Nito.Disposables, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Nito.Disposables.1.2.3\lib\netstandard2.0\Nito.Disposables.dll</HintPath>
+    <Reference Include="Nito.Disposables, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Nito.Disposables.2.0.0\lib\netstandard2.0\Nito.Disposables.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
@@ -85,7 +88,7 @@
       <HintPath>..\..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="Xunit.SkippableFact, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Xunit.SkippableFact.1.3.3\lib\net452\Xunit.SkippableFact.dll</HintPath>
+      <HintPath>..\..\..\packages\Xunit.SkippableFact.1.3.6\lib\net452\Xunit.SkippableFact.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -130,9 +133,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources\MsAccessIdGenerator.mdb" />
   </ItemGroup>
   <ItemGroup>
@@ -144,18 +144,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\xunit.analyzers.0.9.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.targets" Condition="Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.5.0\build\net45\Microsoft.Net.Test.Sdk.targets')" />
   <Import Project="..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.targets" Condition="Exists('..\..\..\packages\Microsoft.NET.Test.Sdk.15.7.2\build\net45\Microsoft.Net.Test.Sdk.targets')" />
 </Project>

--- a/Kros.Utils/tests/Kros.Utils.MsAccess.UnitTests/packages.config
+++ b/Kros.Utils/tests/Kros.Utils.MsAccess.UnitTests/packages.config
@@ -2,21 +2,22 @@
 <packages>
   <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
   <package id="Microsoft.CodeCoverage" version="1.0.3" targetFramework="net462" />
-  <package id="Microsoft.NET.Test.Sdk" version="15.5.0" targetFramework="net462" />
-  <package id="Microsoft.TestPlatform.TestHost" version="15.5.0" targetFramework="net462" />
+  <package id="Microsoft.NET.Test.Sdk" version="15.7.2" targetFramework="net462" />
+  <package id="Microsoft.TestPlatform.TestHost" version="15.7.2" targetFramework="net462" />
   <package id="Nito.AsyncEx.Context" version="5.0.0-pre-05" targetFramework="net462" />
   <package id="Nito.AsyncEx.Tasks" version="5.0.0-pre-05" targetFramework="net462" />
-  <package id="Nito.Disposables" version="1.2.3" targetFramework="net462" />
-  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net462" />
+  <package id="Nito.Disposables" version="2.0.0" targetFramework="net462" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="Validation" version="2.4.18" targetFramework="net462" />
   <package id="xunit" version="2.3.1" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net462" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net462" />
+  <package id="xunit.analyzers" version="0.9.0" targetFramework="net462" />
   <package id="xunit.assert" version="2.3.1" targetFramework="net462" />
   <package id="xunit.core" version="2.3.1" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net462" />
   <package id="xunit.runner.console" version="2.3.1" targetFramework="net462" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Xunit.SkippableFact" version="1.3.3" targetFramework="net462" />
+  <package id="Xunit.SkippableFact" version="1.3.6" targetFramework="net462" />
 </packages>

--- a/Kros.Utils/tests/Kros.Utils.UnitTests/Kros.Utils.UnitTests.csproj
+++ b/Kros.Utils/tests/Kros.Utils.UnitTests/Kros.Utils.UnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Kros.Utils.UnitTests</AssemblyName>
     <RootNamespace>Kros.Utils.UnitTests</RootNamespace>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.0.0-pre-05" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Closes #102
Closes #103
Closes #104
Closes #105

`Kros.KORM` references `System.Configuration.ConfigurationManager` in two versions now:

- Version **4.4.1** for .NET Standard (.NET Core 2.0 and .NET 4.6)
- Version **4.5.0** for .NET Core 2.1.

We cannot use just version 4.5.0, because it requires at least .NET 4.6.1.