### PR TITLE
Primary key detection

### DIFF
--- a/Kros.KORM/src/Kros.KORM/Metadata/Attribute/KeyAttribute.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/Attribute/KeyAttribute.cs
@@ -19,9 +19,28 @@ namespace Kros.KORM.Metadata.Attribute
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
         /// </summary>
+        /// <param name="order">The order of the column in composite primary key.</param>
+        public KeyAttribute(int order)
+            : this(null, order, AutoIncrementMethodType.None)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
+        /// </summary>
         /// <param name="name">The key name.</param>
         public KeyAttribute(string name)
-            : this(name, AutoIncrementMethodType.None)
+            : this(name, 0, AutoIncrementMethodType.None)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The key name.</param>
+        /// <param name="order">The order of the column in composite primary key.</param>
+        public KeyAttribute(string name, int order)
+            : this(name, order, AutoIncrementMethodType.None)
         {
         }
 
@@ -30,7 +49,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// </summary>
         /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
         public KeyAttribute(AutoIncrementMethodType autoIncrementMethodType)
-            : this(null, autoIncrementMethodType)
+            : this(null, 0, autoIncrementMethodType)
         {
         }
 
@@ -40,9 +59,21 @@ namespace Kros.KORM.Metadata.Attribute
         /// <param name="name">The key name.</param>
         /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
         public KeyAttribute(string name, AutoIncrementMethodType autoIncrementMethodType)
+            : this (name, 0, autoIncrementMethodType)
         {
-            this.AutoIncrementMethodType = autoIncrementMethodType;
-            this.Name = name;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The key name.</param>
+        /// <param name="order">The order of the column in composite primary key.</param>
+        /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
+        private KeyAttribute(string name, int order, AutoIncrementMethodType autoIncrementMethodType)
+        {
+            AutoIncrementMethodType = autoIncrementMethodType;
+            Name = name;
+            Order = order;
         }
 
         /// <summary>
@@ -51,8 +82,13 @@ namespace Kros.KORM.Metadata.Attribute
         public AutoIncrementMethodType AutoIncrementMethodType { get; private set; }
 
         /// <summary>
+        /// The order of the column in composite primary key.
+        /// </summary>
+        public int Order { get; }
+
+        /// <summary>
         /// Gets the name of key.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
     }
 }

--- a/Kros.KORM/src/Kros.KORM/Metadata/ColumnInfo.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/ColumnInfo.cs
@@ -36,6 +36,11 @@ namespace Kros.KORM.Metadata
         public bool IsPrimaryKey { get; set; }
 
         /// <summary>
+        /// Gets or sets the order of the column, if it is in composite primary key.
+        /// </summary>
+        public int PrimaryKeyOrder { get; set; }
+
+        /// <summary>
         /// Type of primary key auto increment method.
         /// </summary>
         public AutoIncrementMethodType AutoIncrementMethodType { get; set; } = AutoIncrementMethodType.None;

--- a/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
@@ -324,6 +324,12 @@ namespace Kros.KORM.Metadata
                 throw new CompositePrimaryKeyException(
                     "If primary key is composite, the name of the key must be the same for all its columns.", tableName);
             }
+
+            if (pkAttributes.Any(item => item.Attribute.AutoIncrementMethodType != AutoIncrementMethodType.None))
+            {
+                throw new CompositePrimaryKeyException(
+                    "If primary key is composite, all of its columns must have AutoIncrementMethodType set to None.", tableName);
+            }
         }
 
         #endregion

--- a/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
@@ -4,6 +4,7 @@ using Kros.KORM.Helper;
 using Kros.KORM.Injection;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata.Attribute;
+using Kros.KORM.Properties;
 using Kros.Utils;
 using System;
 using System.Collections.Generic;
@@ -314,21 +315,23 @@ namespace Kros.KORM.Metadata
             var uniqueOrders = new HashSet<int>(pkAttributes.Select(item => item.Attribute.Order));
             if (uniqueOrders.Count != pkAttributes.Count)
             {
-                throw new CompositePrimaryKeyException(
-                    "If primary key is composite, all of its columns must have unique order.", tableName);
+                throw new CompositePrimaryKeyException(Resources.CompositePrimaryKeyMustHaveOrderedColumns, tableName);
             }
 
             var uniqueNames = new HashSet<string>(pkAttributes.Select(item => item.Attribute.Name));
             if (uniqueNames.Count > 1)
             {
-                throw new CompositePrimaryKeyException(
-                    "If primary key is composite, the name of the key must be the same for all its columns.", tableName);
+                throw new CompositePrimaryKeyException(Resources.CompositePrimaryKeyMustHaveSameNameInAllColumns, tableName);
             }
 
             if (pkAttributes.Any(item => item.Attribute.AutoIncrementMethodType != AutoIncrementMethodType.None))
             {
                 throw new CompositePrimaryKeyException(
-                    "If primary key is composite, all of its columns must have AutoIncrementMethodType set to None.", tableName);
+                    string.Format(
+                        Resources.CompositePrimaryKeyCanNotHaveAutoIncrementColumn,
+                        nameof(KeyAttribute.AutoIncrementMethodType),
+                        nameof(AutoIncrementMethodType.None)),
+                    tableName);
             }
         }
 

--- a/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/ConventionModelMapper.cs
@@ -312,14 +312,12 @@ namespace Kros.KORM.Metadata
             List<(ColumnInfo Column, KeyAttribute Attribute)> pkAttributes,
             string tableName)
         {
-            var uniqueOrders = new HashSet<int>(pkAttributes.Select(item => item.Attribute.Order));
-            if (uniqueOrders.Count != pkAttributes.Count)
+            if (pkAttributes.Select(item => item.Attribute.Order).Distinct().Count() != pkAttributes.Count)
             {
                 throw new CompositePrimaryKeyException(Resources.CompositePrimaryKeyMustHaveOrderedColumns, tableName);
             }
 
-            var uniqueNames = new HashSet<string>(pkAttributes.Select(item => item.Attribute.Name));
-            if (uniqueNames.Count > 1)
+            if (pkAttributes.Select(item => item.Attribute.Name).Distinct().Count() > 1)
             {
                 throw new CompositePrimaryKeyException(Resources.CompositePrimaryKeyMustHaveSameNameInAllColumns, tableName);
             }

--- a/Kros.KORM/src/Kros.KORM/Metadata/TableInfo.cs
+++ b/Kros.KORM/src/Kros.KORM/Metadata/TableInfo.cs
@@ -72,12 +72,7 @@ namespace Kros.KORM.Metadata
         /// Gets the columns, which are part of primary key.
         /// </summary>
         public IEnumerable<ColumnInfo> PrimaryKey
-        {
-            get
-            {
-                return _columns.Where(x => x.Value.IsPrimaryKey).Select(p => p.Value);
-            }
-        }
+            => _columns.Values.Where(column => column.IsPrimaryKey).OrderBy(column => column.PrimaryKeyOrder);
 
         /// <summary>
         /// Gets the columns.
@@ -85,13 +80,7 @@ namespace Kros.KORM.Metadata
         /// <value>
         /// The columns.
         /// </value>
-        public IEnumerable<ColumnInfo> Columns
-        {
-            get
-            {
-                return _columns.Values;
-            }
-        }
+        public IEnumerable<ColumnInfo> Columns => _columns.Values;
 
         #endregion
 
@@ -108,10 +97,7 @@ namespace Kros.KORM.Metadata
         public ColumnInfo GetColumnInfo(string columnName)
         {
             Check.NotNull(columnName, nameof(columnName));
-
-            ColumnInfo column = null;
-
-            return (!_columns.TryGetValue(columnName, out column) ? null : column);
+            return _columns.TryGetValue(columnName, out ColumnInfo column) ? column : null;
         }
 
         /// <summary>
@@ -129,8 +115,8 @@ namespace Kros.KORM.Metadata
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
         /// <returns></returns>
-        public ColumnInfo GetColumnInfoByPropertyName(string propertyName) =>
-            (!_properties.Value.TryGetValue(propertyName, out ColumnInfo column) ? null : column);
+        public ColumnInfo GetColumnInfoByPropertyName(string propertyName)
+            => _properties.Value.TryGetValue(propertyName, out ColumnInfo column) ? column : null;
 
         #endregion
     }

--- a/Kros.KORM/src/Kros.KORM/Properties/Resources.Designer.cs
+++ b/Kros.KORM/src/Kros.KORM/Properties/Resources.Designer.cs
@@ -88,6 +88,33 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Primary key of the model is composite. All of its columns must have {0} set to {1}..
+        /// </summary>
+        internal static string CompositePrimaryKeyCanNotHaveAutoIncrementColumn {
+            get {
+                return ResourceManager.GetString("CompositePrimaryKeyCanNotHaveAutoIncrementColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Primary key of the model is composite. All of its columns must have unique order..
+        /// </summary>
+        internal static string CompositePrimaryKeyMustHaveOrderedColumns {
+            get {
+                return ResourceManager.GetString("CompositePrimaryKeyMustHaveOrderedColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Primary key of the model is composite. The name of the key must be the same for all its columns..
+        /// </summary>
+        internal static string CompositePrimaryKeyMustHaveSameNameInAllColumns {
+            get {
+                return ResourceManager.GetString("CompositePrimaryKeyMustHaveSameNameInAllColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The constant for &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string ConstantIsNotSupported {

--- a/Kros.KORM/src/Kros.KORM/Properties/Resources.resx
+++ b/Kros.KORM/src/Kros.KORM/Properties/Resources.resx
@@ -126,6 +126,15 @@
   <data name="CannotOpenConnectionWhenGeneratingPrimaryKeys" xml:space="preserve">
     <value>There was a failure to open the database connection at the time the primary keys are generated. Try add 'Persist Security Info=TRUE' to the connection string.</value>
   </data>
+  <data name="CompositePrimaryKeyCanNotHaveAutoIncrementColumn" xml:space="preserve">
+    <value>Primary key of the model is composite. All of its columns must have {0} set to {1}.</value>
+  </data>
+  <data name="CompositePrimaryKeyMustHaveOrderedColumns" xml:space="preserve">
+    <value>Primary key of the model is composite. All of its columns must have unique order.</value>
+  </data>
+  <data name="CompositePrimaryKeyMustHaveSameNameInAllColumns" xml:space="preserve">
+    <value>Primary key of the model is composite. The name of the key must be the same for all its columns.</value>
+  </data>
   <data name="ConstantIsNotSupported" xml:space="preserve">
     <value>The constant for '{0}' is not supported.</value>
   </data>

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Materializer/ModelMapperShould.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Materializer/ModelMapperShould.cs
@@ -94,6 +94,20 @@ namespace Kros.KORM.UnitTests.Metadata
             public string Data { get; set; }
         }
 
+        private class CompositePrivateKeyWithInvalidAutoIncrementMethodType
+        {
+            [Key(AutoIncrementMethodType.Custom)]
+            public int RecordId1 { get; set; }
+
+            [Key(2)]
+            public int RecordId2 { get; set; }
+
+            [Key(3)]
+            public int RecordId3 { get; set; }
+
+            public string Data { get; set; }
+        }
+
         private class ConventionalPrivateKey
         {
             public string Data { get; set; }
@@ -261,6 +275,16 @@ namespace Kros.KORM.UnitTests.Metadata
 
             tableInfoAction.Should().Throw<CompositePrimaryKeyException>(
                 "If composite primary key has specified name, this name must be the same for all the columns.");
+        }
+
+        [Fact]
+        public void ThrowIfCompositePrimaryKeyHasColumnsWithInvalidAutoIncrementMethodType()
+        {
+            var modelMapper = new ConventionModelMapper();
+            Action tableInfoAction = () => modelMapper.GetTableInfo<CompositePrivateKeyWithInvalidAutoIncrementMethodType>();
+
+            tableInfoAction.Should().Throw<CompositePrimaryKeyException>(
+                $"All columns of the composite primary key must have \"{nameof(KeyAttribute.AutoIncrementMethodType)}\" set to \"{nameof(AutoIncrementMethodType.None)}\".");
         }
 
         [Fact]

--- a/Kros.Utils/src/Kros.Utils/UnitTests/SqlServerTestHelper.cs
+++ b/Kros.Utils/src/Kros.Utils/UnitTests/SqlServerTestHelper.cs
@@ -175,7 +175,8 @@ namespace Kros.UnitTests
             {
                 InitialCatalog = databaseName,
                 Pooling = false,
-                PersistSecurityInfo = true
+                PersistSecurityInfo = true,
+                ConnectTimeout = 2
             };
 
             return new SqlConnection(builder.ToString());


### PR DESCRIPTION
Closes #156 

- If model has primary key specified by attribute and also has a property with conventional name of the primary key, only attributed property is considered.
- If primary key is composite, all of its columns must have order specified and this order must be unique for every column.
- If primary key is composite and the key name is specified, this name must be same for all the columns.
- If primary key is composite, all of its columns must have `AutoIncrementMethodType` set to `None`.
