### PR TITLE
Skip works with OrderBy written as string

### DIFF
--- a/Kros.KORM/src/Kros.KORM/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -57,7 +57,7 @@ namespace Kros.KORM.Query.Sql
             _skip = 0;
             _columnsPosition = 0;
             LinqParameters = new Parameters();
-            _orders = new List<string>();
+            Orders.Clear();
 
             Visit(expression);
 
@@ -69,6 +69,11 @@ namespace Kros.KORM.Query.Sql
 
             return new QueryInfo(SqlBuilder.ToString(), CreateQueryReader());
         }
+
+        /// <summary>
+        /// List of ORDER BY parts for the query.
+        /// </summary>
+        protected List<string> Orders { get; } = new List<string>();
 
         /// <summary>
         /// General builder for the SQL query.
@@ -97,7 +102,7 @@ namespace Kros.KORM.Query.Sql
 
         private void CheckSkip()
         {
-            if ((_skip > 0) && (_orders.Count == 0))
+            if ((_skip > 0) && (Orders.Count == 0))
             {
                 throw new InvalidOperationException(Resources.SkipWithoutOrderByInQuery);
             }
@@ -108,6 +113,27 @@ namespace Kros.KORM.Query.Sql
         /// </summary>
         /// <returns>Implementation of <see cref="IDataReaderEnvelope"/> or <see langword="null"/>.</returns>
         protected virtual IDataReaderEnvelope CreateQueryReader() => _skip > 0 ? new LimitOffsetDataReader(Top, Skip) : null;
+
+        /// <summary>
+        /// Adds ORDER BY clause to the query.
+        /// </summary>
+        protected virtual void AddOrderBy()
+        {
+            if (Orders.Count > 0)
+            {
+                SqlBuilder.Append(" ");
+                SqlBuilder.Append(CreateOrderByString());
+            }
+        }
+
+        /// <summary>
+        /// Creates ORDER BY string.
+        /// </summary>
+        /// <returns>String.</returns>
+        protected string CreateOrderByString()
+            => Orders.Count == 0
+            ? string.Empty
+            : OrderByExpression.OrderByStatement + " " + string.Join(", ", Orders.AsEnumerable().Reverse());
 
         /// <summary>
         /// Adds limit (Top) and offset (Skip) clauses to the query.
@@ -236,7 +262,7 @@ namespace Kros.KORM.Query.Sql
         /// </returns>
         public virtual Expression VisitOrderBy(OrderByExpression orderByExpression)
         {
-            _orders.Add(orderByExpression.OrderByPart);
+            Orders.Add(orderByExpression.OrderByPart);
             return orderByExpression;
         }
 
@@ -562,14 +588,12 @@ namespace Kros.KORM.Query.Sql
             Descending
         }
 
-        private List<string> _orders;
-
         private Expression VisitOrderBy(MethodCallExpression expression, OrderType orderType)
         {
             var lambda = (LambdaExpression)StripQuotes(expression.Arguments[1]);
 
             var ret = Visit(lambda);
-            _orders.Add(LinqStringBuilder.ToString() + " " + (orderType == OrderType.Ascending ? "ASC" : "DESC"));
+            Orders.Add(LinqStringBuilder.ToString() + " " + (orderType == OrderType.Ascending ? "ASC" : "DESC"));
             LinqStringBuilder.Clear();
 
             return ret;
@@ -976,15 +1000,6 @@ namespace Kros.KORM.Query.Sql
             /// Clears this instance.
             /// </summary>
             public void Clear() => _params.Clear();
-        }
-
-        private void AddOrderBy()
-        {
-            if (_orders.Count > 0)
-            {
-                SqlBuilder.Append(" " + OrderByExpression.OrderByStatement + " ");
-                SqlBuilder.Append(string.Join(", ", _orders.AsEnumerable().Reverse()));
-            }
         }
 
         #endregion

--- a/Kros.KORM/src/Kros.KORM/Query/Sql/SqlServer2008SqlGenerator.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Sql/SqlServer2008SqlGenerator.cs
@@ -38,7 +38,7 @@ namespace Kros.KORM.Query.Sql
             }
             else
             {
-                _orderByString = CreateOrderByString(orderByExpression);
+                _orderByString = string.Format("{0} {1}", OrderByExpression.OrderByStatement, orderByExpression.OrderByPart);
                 return orderByExpression;
             }
         }

--- a/Kros.KORM/src/Kros.KORM/Query/Sql/SqlServer2008SqlGenerator.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Sql/SqlServer2008SqlGenerator.cs
@@ -1,7 +1,7 @@
-﻿using System.Linq.Expressions;
-using Kros.KORM.Metadata;
+﻿using Kros.KORM.Metadata;
 using Kros.KORM.Query.Expressions;
 using Kros.KORM.Query.Providers;
+using System.Linq.Expressions;
 
 namespace Kros.KORM.Query.Sql
 {
@@ -18,8 +18,6 @@ namespace Kros.KORM.Query.Sql
         private const string CteQueryLimitOffset =
             "WITH Results_CTE AS ({0}) SELECT * FROM Results_CTE WHERE __RowNum__ > {1} AND __RowNum__ <= {2}";
 
-        private string _orderByString;
-
         /// <summary>
         /// Creates an instance of the generator with specified database mapper <paramref name="databaseMapper"/>.
         /// </summary>
@@ -29,17 +27,11 @@ namespace Kros.KORM.Query.Sql
         }
 
         /// <inheritdoc/>
-        public override Expression VisitOrderBy(OrderByExpression orderByExpression)
+        protected override void AddOrderBy()
         {
             if (Skip == 0)
             {
-                _orderByString = string.Empty;
-                return base.VisitOrderBy(orderByExpression);
-            }
-            else
-            {
-                _orderByString = string.Format("{0} {1}", OrderByExpression.OrderByStatement, orderByExpression.OrderByPart);
-                return orderByExpression;
+                base.AddOrderBy();
             }
         }
 
@@ -52,9 +44,9 @@ namespace Kros.KORM.Query.Sql
             }
             else
             {
-                if (!string.IsNullOrEmpty(_orderByString))
+                if (Orders.Count > 0)
                 {
-                    SqlBuilder.Insert(ColumnsPosition, $", ROW_NUMBER() OVER({_orderByString}) AS __RowNum__");
+                    SqlBuilder.Insert(ColumnsPosition, $", ROW_NUMBER() OVER({CreateOrderByString()}) AS __RowNum__");
                 }
                 string baseSql = SqlBuilder.ToString();
                 SqlBuilder.Clear();

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqFunctionTranslatorShould.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqFunctionTranslatorShould.cs
@@ -362,5 +362,30 @@ namespace Kros.KORM.UnitTests.Query.Sql
 
             TestMethod<Person>();
         }
+
+        [Fact]
+        public void CreateCorrectOrderByIfItIsSpecifiedByStringAndAlsoByExpression()
+        {
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .OrderByDescending(p => p.FirstName)
+                .OrderBy(p => p.LastName);
+
+            AreSame(
+                query,
+                "SELECT Id, FirstName, LastName, PostAddress FROM People ORDER BY Id DESC, FirstName DESC, LastName ASC");
+        }
+
+        [Fact]
+        public void NotThrowWhenUsedSkipWithStringOrderBy()
+        {
+            var visitor = CreateVisitor();
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .Skip(10);
+            Action action = () => visitor.GenerateSql(query.Expression);
+
+            action.Should().NotThrow();
+        }
     }
 }

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorForSqlServer2008Should.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorForSqlServer2008Should.cs
@@ -107,6 +107,31 @@ namespace Kros.KORM.UnitTests.Query.Sql
             AreSame(query, new QueryInfo(expectedQuery, null), 5);
         }
 
+        [Fact]
+        public void CreateCorrectOrderByIfItIsSpecifiedByStringAndAlsoByExpression()
+        {
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .OrderByDescending(p => p.FirstName)
+                .OrderBy(p => p.LastName);
+
+            AreSame(
+                query,
+                "SELECT Id, FirstName, LastName, PostAddress FROM People ORDER BY Id DESC, FirstName DESC, LastName ASC");
+        }
+
+        [Fact]
+        public void NotThrowWhenUsedSkipWithStringOrderBy()
+        {
+            var visitor = CreateVisitor();
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .Skip(10);
+            Action action = () => visitor.GenerateSql(query.Expression);
+
+            action.Should().NotThrow();
+        }
+
         #endregion
 
         #region Helpers

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorForSqlServer2012Should.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorForSqlServer2012Should.cs
@@ -116,6 +116,31 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 5);
         }
 
+        [Fact]
+        public void CreateCorrectOrderByIfItIsSpecifiedByStringAndAlsoByExpression()
+        {
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .OrderByDescending(p => p.FirstName)
+                .OrderBy(p => p.LastName);
+
+            AreSame(
+                query,
+                "SELECT Id, FirstName, LastName, PostAddress FROM People ORDER BY Id DESC, FirstName DESC, LastName ASC");
+        }
+
+        [Fact]
+        public void NotThrowWhenUsedSkipWithStringOrderBy()
+        {
+            var visitor = CreateVisitor();
+            var query = Query<Person>()
+                .OrderBy("Id DESC")
+                .Skip(10);
+            Action action = () => visitor.GenerateSql(query.Expression);
+
+            action.Should().NotThrow();
+        }
+
         #endregion
 
         #region Helpers

--- a/Kros.Utils/src/Kros.Utils/UnitTests/SqlServerTestHelper.cs
+++ b/Kros.Utils/src/Kros.Utils/UnitTests/SqlServerTestHelper.cs
@@ -176,7 +176,7 @@ namespace Kros.UnitTests
                 InitialCatalog = databaseName,
                 Pooling = false,
                 PersistSecurityInfo = true,
-                ConnectTimeout = 2
+                ConnectTimeout = 4
             };
 
             return new SqlConnection(builder.ToString());


### PR DESCRIPTION
Closes #155 

* `OrderBy("Id")` works with `Skip()`.
* Now works mixing string and expression `OrderBy()`:

```csharp
var query = Query<Person>()
  .OrderBy("Id DESC")
  .OrderBy(p => p.LastName);
```