### PR TITLE
Replaced deprecated LicenseUrl element in NuGet packages.

### DIFF
--- a/Kros.KORM/src/Kros.KORM.Extensions.Asp/Kros.KORM.Extensions.Asp.csproj
+++ b/Kros.KORM/src/Kros.KORM.Extensions.Asp/Kros.KORM.Extensions.Asp.csproj
@@ -20,7 +20,7 @@
     <PackageTags>
       Kros;KORM;Asp.Net Core;Kros.KORM
     </PackageTags>
-    <PackageLicenseUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Kros-sk/Kros.Libs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Kros.KORM/src/Kros.KORM.MsAccess/Kros.KORM.MsAccess.nuspec
+++ b/Kros.KORM/src/Kros.KORM.MsAccess/Kros.KORM.MsAccess.nuspec
@@ -6,7 +6,7 @@
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/README.md</projectUrl>
     <iconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
+++ b/Kros.KORM/src/Kros.KORM/Kros.KORM.csproj
@@ -22,7 +22,7 @@
     <PackageProjectUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/README.md</PackageProjectUrl>
     <PackageTags>Kros;KORM;ORM;Database;DAL;SQL;Database;MSSQL;Data;BulkInsert;BulkOperation;BulkCopy;
     BulkUpdate;Bulk Insert;Bulk Update</PackageTags>
-    <PackageLicenseUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Kros-sk/Kros.Libs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Kros.Utils/src/Kros.Utils.MsAccess/Kros.Utils.MsAccess.nuspec
+++ b/Kros.Utils/src/Kros.Utils.MsAccess/Kros.Utils.MsAccess.nuspec
@@ -6,7 +6,7 @@
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/README.md</projectUrl>
     <iconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
+++ b/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/README.md</PackageProjectUrl>
     <PackageTags>Kros;Utils;Utility;Helpers;Extensions;DatabaseSchema;BulkInsert;BulkOperation; BulkUpdate;
     Bulk Insert; Bulk Update;</PackageTags>
-    <PackageLicenseUrl>https://github.com/Kros-sk/Kros.Libs/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://en.gravatar.com/userimage/137934964/524e95fbd8c2e8779e02819ab6902bef.png</PackageIconUrl>
     <PackageReleaseNotes>https://github.com/Kros-sk/Kros.Libs/releases</PackageReleaseNotes>
   </PropertyGroup>


### PR DESCRIPTION
Closes #178 
