### PR TITLE
Added asynchronous variant of method ExecuteNonQuery

### DIFF
--- a/Kros.KORM/src/Kros.KORM/Database.cs
+++ b/Kros.KORM/src/Kros.KORM/Database.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Kros.KORM
 {
@@ -195,27 +196,19 @@ namespace Kros.KORM
         /// <typeparam name="T">Type of model, for which querying.</typeparam>
         public IQuery<T> Query<T>() => new Query<T>(_databaseMapper, _queryProvider);
 
-        /// <summary>
-        /// Executes arbitrary query.
-        /// </summary>
-        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
-        /// <returns>
-        /// Number of affected rows.
-        /// </returns>
+        /// <inheritdoc/>
         public int ExecuteNonQuery(string query) => _queryProvider.ExecuteNonQuery(query);
 
-        /// <summary>
-        /// Executes arbitrary query with parameters.
-        /// </summary>
-        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
-        /// <param name="parameters">The query parameters.</param>
-        /// <returns>
-        /// Number of affected rows.
-        /// </returns>
-        /// <exception cref="ArgumentException">Value of any of the parameters is NULL and its data type
-        /// (<see cref="CommandParameter.DataType"/>) is not set.</exception>
+        /// <inheritdoc/>
         public int ExecuteNonQuery(string query, CommandParameterCollection parameters)
             => _queryProvider.ExecuteNonQuery(query, parameters);
+
+        /// <inheritdoc/>
+        public async Task<int> ExecuteNonQueryAsync(string query) =>await  _queryProvider.ExecuteNonQueryAsync(query);
+
+        /// <inheritdoc/>
+        public async Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
+            => await _queryProvider.ExecuteNonQueryAsync(query, parameters);
 
         /// <summary>
         /// Executes the query, and returns the first column of the first row in the result set returned by the query.

--- a/Kros.KORM/src/Kros.KORM/Database.cs
+++ b/Kros.KORM/src/Kros.KORM/Database.cs
@@ -204,7 +204,7 @@ namespace Kros.KORM
             => _queryProvider.ExecuteNonQuery(query, parameters);
 
         /// <inheritdoc/>
-        public async Task<int> ExecuteNonQueryAsync(string query) =>await  _queryProvider.ExecuteNonQueryAsync(query);
+        public async Task<int> ExecuteNonQueryAsync(string query) => await _queryProvider.ExecuteNonQueryAsync(query);
 
         /// <inheritdoc/>
         public async Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)

--- a/Kros.KORM/src/Kros.KORM/IDatabase.cs
+++ b/Kros.KORM/src/Kros.KORM/IDatabase.cs
@@ -5,6 +5,7 @@ using Kros.KORM.Query;
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Kros.KORM
 {
@@ -85,6 +86,27 @@ namespace Kros.KORM
         /// Number of affected rows.
         /// </returns>
         int ExecuteNonQuery(string query, CommandParameterCollection parameters);
+
+        /// <summary>
+        /// Asynchronously executes arbitrary query.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query);
+
+        /// <summary>
+        /// Asynchronously executes arbitrary query with parameters.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <param name="parameters">The query parameters.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters);
 
         /// <summary>
         /// Executes the query, and returns the first column of the first row in the result set returned by the query.

--- a/Kros.KORM/src/Kros.KORM/Query/Providers/IQueryProvider.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Providers/IQueryProvider.cs
@@ -125,6 +125,27 @@ namespace Kros.KORM.Query
         int ExecuteNonQuery(string query, CommandParameterCollection parameters);
 
         /// <summary>
+        /// Asynchronously executes arbitrary query.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query);
+
+        /// <summary>
+        /// Asynchronously executes arbitrary query with parameters.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <param name="parameters">The query parameters.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters);
+
+        /// <summary>
         /// Executes the stored procedure with parameters and returns its result. The result can be scalar value
         /// (primitive or complex &#8211; class type), or a list of values
         /// (<see cref="IEnumerable{T}">IEnumerable&lt;T&gt;</see>).

--- a/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
+++ b/Kros.KORM/src/Kros.KORM/Query/Providers/QueryProvider.cs
@@ -304,28 +304,10 @@ namespace Kros.KORM.Query
             return await command.ExecuteNonQueryAsync();
         }
 
-        /// <summary>
-        /// Executes arbitrary query.
-        /// </summary>
-        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
-        /// <returns>
-        /// Number of affected rows.
-        /// </returns>
-        public int ExecuteNonQuery(string query)
-        {
-            return ExecuteNonQuery(query, null);
-        }
+        /// <inheritdoc/>
+        public int ExecuteNonQuery(string query) => ExecuteNonQuery(query, null);
 
-        /// <summary>
-        /// Executes arbitrary query with parameters.
-        /// </summary>
-        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
-        /// <param name="parameters">The query parameters.</param>
-        /// <returns>
-        /// Number of affected rows.
-        /// </returns>
-        /// <exception cref="ArgumentException">Value of any of the parameters is NULL and its data type
-        /// (<see cref="CommandParameter.DataType"/>) is not set.</exception>
+        /// <inheritdoc/>
         public int ExecuteNonQuery(string query, CommandParameterCollection parameters)
         {
             CheckCommandParameters(parameters);
@@ -333,15 +315,28 @@ namespace Kros.KORM.Query
             using (OpenConnection())
             using (DbCommand command = CreateCommand(query, parameters))
             {
-                return command.ExecuteNonQuery();
+                return ExecuteNonQueryCommand(command);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<int> ExecuteNonQueryAsync(string query) => await ExecuteNonQueryAsync(query, null);
+
+        /// <inheritdoc/>
+        public async Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
+        {
+            CheckCommandParameters(parameters);
+
+            using (OpenConnection())
+            using (DbCommand command = CreateCommand(query, parameters))
+            {
+                return await ExecuteNonQueryCommandAsync(command);
             }
         }
 
         /// <inheritdoc cref="IQueryProvider.ExecuteStoredProcedure{TResult}(string)"/>
         public TResult ExecuteStoredProcedure<TResult>(string storedProcedureName)
-        {
-            return ExecuteStoredProcedure<TResult>(storedProcedureName, null);
-        }
+            => ExecuteStoredProcedure<TResult>(storedProcedureName, null);
 
         /// <inheritdoc cref="IQueryProvider.ExecuteStoredProcedure{TResult}(string, CommandParameterCollection)"/>
         public TResult ExecuteStoredProcedure<TResult>(string storedProcedureName, CommandParameterCollection parameters)

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -356,6 +356,16 @@ namespace Kros.KORM.UnitTests
             }
 
             public bool SupportsPrepareCommand() => true;
+
+            public Task<int> ExecuteNonQueryAsync(string query)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         #endregion

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
@@ -16,6 +16,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Kros.KORM.UnitTests.Query.Providers
@@ -270,6 +271,38 @@ END";
 
                 QueryProvider provider = CreateQueryProvider(helper.Connection);
                 int result = provider.ExecuteNonQuery(query);
+                result.Should().Be(3); // Deleted 3 rows.
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteNonQueryCommandAsync()
+        {
+            using (SqlServerTestHelper helper = CreateHelper(CreateTable_TestTable))
+            {
+                var query = $"INSERT INTO {Table_TestTable} (Id, Number, Description) VALUES (@Id, @Number, @Description)";
+                var parameters = new CommandParameterCollection
+                {
+                    { "@Id", 6 },
+                    { "@Number", 666 },
+                    { "@Description", "Sed ac lobortis magna." }
+                };
+
+                QueryProvider provider = CreateQueryProvider(helper.Connection);
+                int result = await provider.ExecuteNonQueryAsync(query, parameters);
+                result.Should().Be(1); // Inserted 1 row.
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteNonQueryCommandWithoutParametersAsync()
+        {
+            using (SqlServerTestHelper helper = CreateHelper(CreateTable_TestTable))
+            {
+                var query = $"DELETE FROM {Table_TestTable}";
+
+                QueryProvider provider = CreateQueryProvider(helper.Connection);
+                int result = await provider.ExecuteNonQueryAsync(query);
                 result.Should().Be(3); // Deleted 3 rows.
             }
         }

--- a/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/Kros.KORM/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -241,6 +241,16 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
+            public Task<int> ExecuteNonQueryAsync(string query)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
+            {
+                throw new NotImplementedException();
+            }
+
             public int ExecuteNonQueryCommand(IDbCommand command)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Closes #168 

Added asynchronous variant of methods `ExecuteNonQuery` into `Database`.

```CSharp
using (IDatabase database = new Database(connectionString, provider))
{
  var query = "DELETE FROM Person";
  int result = await provider.ExecuteNonQueryAsync(query);
}
```


