### PR TITLE
Nuget reference for full .NET FW 4.6.x

### DIFF
--- a/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
+++ b/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
@@ -23,19 +23,23 @@
     <PackageReleaseNotes>https://github.com/Kros-sk/Kros.Libs/releases</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />    
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Net.Http.Headers">
       <Version>2.1.1</Version>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />      
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Net.Http.Headers">
       <Version>2.1.1</Version>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>  
   <ItemGroup>
     <None Remove="Kros.Utils.xml" />
     <None Remove="Resources\SqlIdGeneratorStoredProcedureScript.sql" />

--- a/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
+++ b/Kros.Utils/src/Kros.Utils/Kros.Utils.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
     <Company>KROS a.s.</Company>
     <Title>Kros.Utils</Title>
-    <Version>1.8.1</Version>
+    <Version>1.9.1</Version>
     <Authors>KROS a.s.</Authors>
     <Description>General utilities and helpers.</Description>
     <Copyright>Copyright © KROS a.s.</Copyright>


### PR DESCRIPTION
Closes #182 

Change reference of System.Net.Http from Nuget reference to system Framework reference (for full .NET Framework 4.6.x) 
For .Net standard the reference is still from Nuget.
